### PR TITLE
Update workflows and backend configuration for OpenTofu migration

### DIFF
--- a/.github/workflows/non-production.yml
+++ b/.github/workflows/non-production.yml
@@ -18,19 +18,19 @@ permissions:
 jobs:
   main:
     name: "Main"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'osinfra-sa'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Non-Production: Main"
       service_account: plt-lz-identity-github@plt-lz-backend-tfa3-nonprod.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tfa3-nonprod/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/non-production.tfvars
       opentofu_state_bucket: plt-lz-identity-ecf2-nonprod
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: main-non-production
       workload_identity_provider: projects/992372365053/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -18,19 +18,19 @@ permissions:
 jobs:
   main:
     name: "Main"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.event.workflow_run.conclusion == 'success'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Production: Main"
       service_account: plt-lz-identity-github@plt-lz-backend-tf5f-prod.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf5f-prod/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/production.tfvars
       opentofu_state_bucket: plt-lz-identity-d3c2-prod
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: main-production
       workload_identity_provider: projects/134040294660/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -19,19 +19,19 @@ permissions:
 jobs:
   main:
     name: "Main"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox: Main"
       service_account: plt-lz-identity-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/sandbox.tfvars
       opentofu_state_bucket: plt-lz-identity-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: main-sandbox
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}

--- a/backend.tofu
+++ b/backend.tofu
@@ -1,5 +1,13 @@
+# Backend Configuration
+# https://opentofu.org/docs/language/settings/backends/configuration
+
 terraform {
+  # Google Cloud Storage
+  # https://opentofu.org/docs/language/settings/backends/gcs
+
   backend "gcs" {
-    prefix = "google-cloud-workload-identity"
+    bucket             = var.state_bucket
+    kms_encryption_key = var.state_kms_encryption_key
+    prefix             = var.state_prefix
   }
 }

--- a/main.tofu
+++ b/main.tofu
@@ -1,4 +1,40 @@
 terraform {
+  # State and Plan Encryption
+  # https://opentofu.org/docs/language/state/encryption
+
+  # The commented out sections below demonstrate how to configure
+  # fallback encryption methods for state and plan files for bootstrapping.
+
+  encryption {
+    method "unencrypted" "migrate" {}
+
+    key_provider "gcp_kms" "default" {
+      kms_encryption_key = var.state_kms_encryption_key
+      key_length         = 32
+    }
+
+    method "aes_gcm" "default" {
+      keys = key_provider.gcp_kms.default
+    }
+
+    plan {
+      method = method.aes_gcm.default
+      # enforced = true
+
+      fallback {
+        method = method.unencrypted.migrate
+      }
+    }
+
+    state {
+      method = method.aes_gcm.default
+      # enforced = true
+
+      fallback {
+        method = method.unencrypted.migrate
+      }
+    }
+  }
 
   # Requiring Providers
   # https://opentofu.org/docs/language/providers/requirements#requiring-providers

--- a/variables.tofu
+++ b/variables.tofu
@@ -42,3 +42,21 @@ variable "project_folder_id" {
   description = "The numeric ID of the folder this project should be created under. Only one of `org_id` or `folder_id` may be specified"
   type        = string
 }
+
+# These three state_* variables are required for early variable evaluation for backend and provider configuration.
+# They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
+
+variable "state_bucket" {
+  description = "The name of the GCS bucket to store state files"
+  type        = string
+}
+
+variable "state_kms_encryption_key" {
+  description = "The KMS encryption key for state and plan files"
+  type        = string
+}
+
+variable "state_prefix" {
+  description = "The prefix for state files in the GCS bucket"
+  type        = string
+}


### PR DESCRIPTION
- Updated workflow references to use OpenTofu v0.2.9 in non-production, production, and sandbox YAML files.
- Added KMS encryption key parameter to workflows.
- Enhanced backend configuration in backend.tofu for GCS with KMS encryption.
- Introduced state management variables in variables.tofu for better configuration handling.